### PR TITLE
Date discrepancy between text and Listing 2.016.sql

### DIFF
--- a/PostgreSQL/Chapter 02/Listing 2.016.sql
+++ b/PostgreSQL/Chapter 02/Listing 2.016.sql
@@ -5,5 +5,5 @@ SET search_path = SalesOrdersSample;
 
 SELECT CustomerID, Sum(OrderTotal)
 FROM Orders
-WHERE OrderDate > DATE '2016-04-01'
+WHERE OrderDate > DATE '2015-12-01'
 GROUP BY CustomerID;


### PR DESCRIPTION
The text uses '2015-12-01'.  This value return rows, while '2016-04-01' does not return any rows.