### PR TITLE
Syntax Error in Listing 2.019.sql

### DIFF
--- a/PostgreSQL/Chapter 02/Listing 2.019.sql
+++ b/PostgreSQL/Chapter 02/Listing 2.019.sql
@@ -4,8 +4,7 @@
 SET search_path = SalesOrdersSample;
 
 CREATE FUNCTION UpdateOrdersOrderTotals() 
-RETURNS trigger
-LANGUAGE plpgsql AS 
+RETURNS trigger AS 
 $BODY$
     BEGIN
 	  UPDATE  Orders
@@ -20,7 +19,7 @@ $BODY$
 	    SELECT OrderNumber FROM NEW
 	  );
     END;
-$BODY$
+$BODY$ LANGUAGE plpgsql;
 
 CREATE TRIGGER updateOrdersOrderTotalsTrig AFTER INSERT OR UPDATE OR DELETE
 ON Orders 


### PR DESCRIPTION
CREATE Function statement will not execute since it is not terminated with a semicolon.  Also, I reformated the function to match the convention shown in https://www.postgresql.org/docs/9.6/static/plpgsql-trigger.html.