### PR TITLE
Missing Semicolon Termination

### DIFF
--- a/PostgreSQL/Chapter 04/Listing 4.005.sql
+++ b/PostgreSQL/Chapter 04/Listing 4.005.sql
@@ -11,4 +11,4 @@ FROM Products AS P
 WHERE NOT EXISTS 
   (SELECT * 
    FROM Order_Details AS OD 
-   WHERE OD.ProductNumber = P.ProductNumber)
+   WHERE OD.ProductNumber = P.ProductNumber);


### PR DESCRIPTION
Postgresql's command-line editor - psql - will not execute a query unless it is terminated with a semicolon.