### PR TITLE
Missing Semicolon Termination

### DIFF
--- a/PostgreSQL/Chapter 04/Listing 4.013.sql
+++ b/PostgreSQL/Chapter 04/Listing 4.013.sql
@@ -18,7 +18,7 @@ BEGIN
 		ON Products.ProductNumber = Order_Details.ProductNumber
 	WHERE ProductName = ProdName;
 END;
-$BODY$
+$BODY$;
 
 --Schema must be included for function invocation to work
 SELECT C.CustomerID, C.CustFirstName, C.CustLastName
@@ -49,7 +49,7 @@ BEGIN
 		ON Products.ProductNumber = Order_Details.ProductNumber
 	WHERE ProductName LIKE CONCAT('%', ProdName, '%');
 END;
-$BODY$
+$BODY$;
 
 --Schema must be included for function invocation to work
 SELECT C.CustomerID, C.CustFirstName, C.CustLastName


### PR DESCRIPTION
Postgresql's command line editor will not execute the CREATE FUNCTION statement unless it is terminated with a semicolon.