### PR TITLE
Listing 9.22 - Alias Error

### DIFF
--- a/PostgreSQL/Chapter 09/Listing 9.022.sql
+++ b/PostgreSQL/Chapter 09/Listing 9.022.sql
@@ -8,8 +8,8 @@ SET search_path = Item56Example;
 
 SELECT D.FullDate, 
   A.ApptDescription ,
-  CAST(A.ApptStartDate AS timestamp) + SECOND(A.ApptStartTime) SECONDS AS ApptStart ,
-  CAST(A.ApptEndDate AS timestamp) + SECOND(A.ApptEndTime) SECONDS AS ApptEnd
+  CAST(A.ApptStartDate AS timestamp) + SECOND(A.ApptStartTime) AS ApptStart ,
+  CAST(A.ApptEndDate AS timestamp) + SECOND(A.ApptEndTime) AS ApptEnd
 FROM DimDate AS D LEFT JOIN Appointments AS A
   ON D.FullDate = A.ApptStartDate
 ORDER BY D.FullDate;


### PR DESCRIPTION
Unless  you casting a string with the word SECONDS (i.e. CAST ( '10 SECONDS' AS INTERVAL)), the SECONDS will be treated as a column alias.